### PR TITLE
Kindle Paperwhite browser compatibility changes

### DIFF
--- a/COPS/CHANGELOG.md
+++ b/COPS/CHANGELOG.md
@@ -1,8 +1,9 @@
 # HA COPS Changelog
 
-## [1.7.1] - 2023-06-15
+## [1.7.2] - 2023-06-15
 
-Changed default template to default as Kindle compatibility issue with Bootstrap2
+- Changed default template to default as Kindle compatibility issue with Bootstrap2
+- Test to see if issue with changing format is down to single vs doublequotes
 
 ## [1.7] - 2023-06-15
 

--- a/COPS/config.yaml
+++ b/COPS/config.yaml
@@ -1,5 +1,5 @@
 name: "HA COPS"
-version: "1.7.1"
+version: "1.7.2"
 slug: "ha-cops"
 description: "Minimal Calibre library web interface"
 url: "https://github.com/dunxd/HomeAssistantAddons/tree/main/COPS"

--- a/COPS/cops-1.3.4/templates/bootstrap2/header.html
+++ b/COPS/cops-1.3.4/templates/bootstrap2/header.html
@@ -16,10 +16,10 @@
           <button type="submit" class="btn btn-success"><span class="glyphicon glyphicon-search"></span></button>
         </div>
       </div>
-    </form>     
+    </form>
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="#" onclick='Cookies.set("template", "default", { expires: 365 }); window.location.reload(true); ' data-toggle="tooltip" data-placement="bottom" title="" data-original-title="Default COPS template">
+        <li><a href="#" onclick="Cookies.set('template', 'default', { expires: 365 }); window.location.reload(true);" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="Default COPS template">
           <span class="glyphicon glyphicon-picture"></span><span class="hidden-sm"> Default COPS template</span>
         </a></li>
         <li><a href="{{=it.abouturl}}" data-toggle="tooltip" data-placement="bottom" title="" data-original-title="{{=it.c.i18n.aboutTitle}}">


### PR DESCRIPTION
Switch to use default template over bootstrap2 due to issues on Kindle Paperwhite.

Change HTML to use doublequotes for javascript to change template.