### PR TITLE
Roll back to Monocle

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
   },
   "customizations": {
     "vscode": {
-      "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode"],
+      "extensions": ["timonwong.shellcheck", "esbenp.prettier-vscode", ""],
       "settings": {
         "terminal.integrated.profiles.linux": {
           "zsh": {
@@ -19,7 +19,8 @@
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,
-        "files.trimTrailingWhitespace": true
+        "files.trimTrailingWhitespace": true,
+        "php.executablePath": "/usr/local/bin/php"
       }
     }
   },

--- a/COPS/CHANGELOG.md
+++ b/COPS/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HA COPS Changelog
 
+## [1.20] - 2024-03-12
+
+- Revert epubreader to Monocle - issues with mobile browser view with Intity that need resolving.
+
 ## [1.19] - 2024-03-10
 
 - Incorporate [COPS 2.5.0](https://github.com/mikespub-org/seblucas-cops/releases/tag/2.5.0)

--- a/COPS/config.yaml
+++ b/COPS/config.yaml
@@ -1,5 +1,5 @@
 name: "HA COPS"
-version: "1.19"
+version: "1.20"
 slug: "ha-cops"
 description: "Minimal Calibre library web interface"
 url: "https://github.com/dunxd/HomeAssistantAddons/tree/main/COPS"

--- a/COPS/cops-2.5.0/config_default.php
+++ b/COPS/cops-2.5.0/config_default.php
@@ -534,4 +534,4 @@ $config['cops_api_key'] = '';
  * 'monocle' (default)
  * 'epubjs'
  */
-$config['cops_epub_reader'] = 'epubjs';
+$config['cops_epub_reader'] = 'monocle';


### PR DESCRIPTION
Intity epubreader doesn't currently work well with mobile browser, so rolling back to Monocle till it is fixed.