### PR TITLE
Revert "1.21.2"

### DIFF
--- a/COPS/CHANGELOG.md
+++ b/COPS/CHANGELOG.md
@@ -1,9 +1,5 @@
 # HA COPS Changelog
 
-## [1.21.2] - 2024-05-12
-
-- Better testing of _epubjs_ revealed problem was person in the chair so reverted to using it as default :-)
-
 ## [1.21.1] - 2024-05-12
 
 - Switch back to _monocle_ as default in-browser reader as it still doesn't support small screens well enough

--- a/COPS/config.yaml
+++ b/COPS/config.yaml
@@ -1,5 +1,5 @@
 name: "HA COPS"
-version: "1.21.2"
+version: "1.21.1"
 slug: "ha-cops"
 description: "Minimal Calibre library web interface"
 url: "https://github.com/dunxd/HomeAssistantAddons/tree/main/COPS"
@@ -21,7 +21,7 @@ map:
 options:
   title: "COPS"
   rsync: true
-  reader: ebubjs
+  reader: monocle
 schema:
   title: str
   rsync: bool


### PR DESCRIPTION
epubjs still works really badly on mobile browsers. Not ready for mainstream