### PR TITLE
Folder path

### DIFF
--- a/COPS/CHANGELOG.md
+++ b/COPS/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HA COPS Changelog
 
+## [1.24] - 2024-06-23
+
+- Allow specifying a different path within HA's media folder - this is useful if you mounted your Calibre Libary somewhere other than books, or have uploaded it to a different directory
+
 ## [1.23] - 2024-06-01
 
 - Incorporate [COPS 2.7.1](https://github.com/mikespub-org/seblucas-cops/releases/tag/2.7.2)

--- a/COPS/DOCS.md
+++ b/COPS/DOCS.md
@@ -19,7 +19,7 @@ This is useful if you don't want to run another computer 24/7 or if storage spac
 rsync -av --exclude '*.original_*' ~/Calibre\ Library/* rsync://{server_address}:8873/books
 ```
 
-You may need to change `~/Calibre\ Library` to where your Calibre library is stored - the above example works for a Mac running a standard install of Calibre.
+You may need to change `~/Calibre\ Library` to where your Calibre library is stored - the above example works for a Mac running a standard install of Calibre. The rsync path always ends in `/books`, even if you changed the folder path in the add-on config.
 
 You can use this command to sync any changes made in Calibre - new books added, changes to metadata etc. You can exclude files from being transferred using [the `--exclude` option for rsync](https://www.man7.org/linux/man-pages/man1/rsync.1.html#FILTER_RULES). In the example above I have excluded file types starting `.original_*` type files, as mostly these are duplicates of files converted in Calibre, and original_epub and original_azw are ignored by COPS anyway. Suggestions for improving this are welcome.
 

--- a/COPS/config.yaml
+++ b/COPS/config.yaml
@@ -1,5 +1,5 @@
 name: "HA COPS"
-version: "1.24.2"
+version: "1.24"
 slug: "ha-cops"
 description: "Minimal Calibre library web interface"
 url: "https://github.com/dunxd/HomeAssistantAddons/tree/main/COPS"

--- a/COPS/config.yaml
+++ b/COPS/config.yaml
@@ -1,5 +1,5 @@
 name: "HA COPS"
-version: "1.23"
+version: "1.24.2"
 slug: "ha-cops"
 description: "Minimal Calibre library web interface"
 url: "https://github.com/dunxd/HomeAssistantAddons/tree/main/COPS"
@@ -20,15 +20,17 @@ map:
   - media:rw
 options:
   title: "COPS"
+  library_folder: books
   rsync: true
   reader: monocle
 schema:
   title: str
+  library_folder: str
   rsync: bool
   reader: list(monocle|epubjs)
   smtp_host: str?
   smtp_username: str?
   smtp_password: password?
-  smtp_secure: match(^$|ssl|tls)?
+  smtp_secure: list(ssl|tls)?
   smtp_port: int?
   address_from: email?

--- a/COPS/cops-2.7.1/config_local.php
+++ b/COPS/cops-2.7.1/config_local.php
@@ -17,7 +17,7 @@ if (!isset($config)) {
  * containing all the formats.
  * BEWARE : it has to end with a /
  */
-$config['calibre_directory'] = '/media/books/';
+$config['calibre_directory'] = 'library/';
 
 /*
  * use URL rewriting for downloading of ebook in HTML catalog

--- a/COPS/rsyncd.conf
+++ b/COPS/rsyncd.conf
@@ -9,7 +9,7 @@ log file = /var/log/rsync.log
 port = 873
 
 [books]
-    path = /media/books
+    path = library
     comment = eBook Library for COPS
     read only = false
     list = false

--- a/COPS/run.sh
+++ b/COPS/run.sh
@@ -3,6 +3,7 @@
 
 #Capture Options set by user
 TITLE=$(bashio::config 'title')
+LIBRARY_PATH="/media/$(bashio::config 'library_folder')"
 
 COPS_CONFIG="/cops/config_local.php"
 
@@ -57,15 +58,14 @@ fi
 echo "$CONFIG_STR" >> "$COPS_CONFIG"
 
 # Create a books directory in /media on the host if it doesn't already exist
-mkdir -p /media/books
+mkdir -p $LIBRARY_PATH
 cd /cops || return
-# Create a link to the books directory called library
-ln -s /media/books library
+# Create a link to the configured directory called library
+ln -s $LIBRARY_PATH library
 
 # Start rsync and php daemons depending on rsync setting
 if [ "$(bashio::config 'rsync')" = "true" ]
 then
-
     bashio::log.green 'starting rsync and php servers'
     rsync --daemon & php -S 0.0.0.0:8000
 else

--- a/COPS/run.sh
+++ b/COPS/run.sh
@@ -6,6 +6,7 @@ TITLE=$(bashio::config 'title')
 LIBRARY_PATH="/media/$(bashio::config 'library_folder')"
 
 COPS_CONFIG="/cops/config_local.php"
+RSYNCD_CONFIG="/etc/rsncd.conf"
 
 # Create lines for the config file here
 CONFIG_STR=$(
@@ -58,10 +59,10 @@ fi
 echo "$CONFIG_STR" >> "$COPS_CONFIG"
 
 # Create a books directory in /media on the host if it doesn't already exist
-mkdir -p $LIBRARY_PATH
+mkdir -p "$LIBRARY_PATH"
 cd /cops || return
 # Create a link to the configured directory called library
-ln -s $LIBRARY_PATH library
+ln -s "$LIBRARY_PATH" library
 
 # Start rsync and php daemons depending on rsync setting
 if [ "$(bashio::config 'rsync')" = "true" ]

--- a/COPS/run.sh
+++ b/COPS/run.sh
@@ -3,10 +3,9 @@
 
 #Capture Options set by user
 TITLE=$(bashio::config 'title')
-LIBRARY_PATH="/media/$(bashio::config 'library_folder')"
+LIBRARY_FOLDER="/media/$(bashio::config 'library_folder')"
 
 COPS_CONFIG="/cops/config_local.php"
-RSYNCD_CONFIG="/etc/rsncd.conf"
 
 # Create lines for the config file here
 CONFIG_STR=$(
@@ -59,10 +58,11 @@ fi
 echo "$CONFIG_STR" >> "$COPS_CONFIG"
 
 # Create a books directory in /media on the host if it doesn't already exist
-mkdir -p "$LIBRARY_PATH"
+mkdir -p "$LIBRARY_FOLDER"
 cd /cops || return
-# Create a link to the configured directory called library
-ln -s "$LIBRARY_PATH" library
+# Create a link to the configured directory called library - this works with
+# rsync as well as for locating the Calibre Library
+ln -s "$LIBRARY_FOLDER" library
 
 # Start rsync and php daemons depending on rsync setting
 if [ "$(bashio::config 'rsync')" = "true" ]

--- a/COPS/translations/en.yaml
+++ b/COPS/translations/en.yaml
@@ -2,6 +2,9 @@ configuration:
   title:
     name: Library Title
     description: The display name for your library, which will be displayed at the top of the library home.
+  library_folder:
+    name: Library Folder
+    description: The name of the folder inside media where your books will be stored.  If your Calibre Library is on a network share, this is where it is mounted. If local this is the relative path within HA's media folder. By default, this is set to books, mapping to /media/books/.
   rsync:
     name: Enable rsync
     description: Enable rsync server in the configuration - if your Calibre Library is on a network share you do NOT need this enabled.


### PR DESCRIPTION
Allow users to configure a different folder within Home Assistant's `media` folder in case they mounted or copied their Calibre Library into a different location.  This location still must be within the `media` location in HA.